### PR TITLE
feat: add universal binary support for mac

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,9 @@ builds:
     goarch:
       - amd64
 
+universal_binaries:
+  - replace: true
+  
 brews:
   - tap:
       owner: etsy


### PR DESCRIPTION
I wanted to add support for generating universal binaries for Macs, I ran `goreleaser release --snapshot --rm-dist` locally and it generated this:

```ruby
# typed: false
# frozen_string_literal: true

# This file was generated by GoReleaser. DO NOT EDIT.
class TerraformDemux < Formula
    desc "A user-friendly launcher (à la Bazelisk) for Terraform."
    homepage "https://github.com/etsy/terraform-demux"
    version "1.0.1-SNAPSHOT-f599d6e"
    license "Apache-2.0"
  
    on_macos do
      url "https://github.com/mskdenigma/terraform-demux/releases/download/v1.0.1/terraform-demux_1.0.1-SNAPSHOT-f599d6e_darwin_all.tar.gz"
      sha256 "205c5cfd3708f7694d55398d2d34ce0ff9fb34c5d75ed7a3241e0f19c5661225"
  
      def install
        bin.install "terraform-demux"
        bin.install_symlink bin/"terraform-demux" => "terraform"
      end
    end
  
    on_linux do
      if Hardware::CPU.intel?
        url "https://github.com/mskdenigma/terraform-demux/releases/download/v1.0.1/terraform-demux_1.0.1-SNAPSHOT-f599d6e_linux_amd64.tar.gz"
        sha256 "9c64402c110c57494de7860cab73cb64ccf7f2b7b574b072b1e37eed26755f33"
  
        def install
          bin.install "terraform-demux"
          bin.install_symlink bin/"terraform-demux" => "terraform"
        end
      end
    end
  
    conflicts_with "terraform"
  end
  ```

EDIT: Just some added context from the [goreleaser documentation on universal binaries](https://goreleaser.com/customization/universalbinaries/) on what replace does

```golang
# Whether to remove the previous single-arch binaries from the artifact list.
# If left as false, your end release might have both several macOS archives: amd64, arm64 and all.
#
# Defaults to false.
replace: true
```