### PR TITLE
fix: download Intel build when M1 build not available for terraform

### DIFF
--- a/internal/releaseapi/client.go
+++ b/internal/releaseapi/client.go
@@ -96,9 +96,21 @@ func (c *Client) DownloadRelease(r Release, os, arch string) (string, error) {
 	}
 
 	if matchingBuild.URL == "" {
-		return "", errors.Errorf(
-			"could not find matching build for OS '%s' and arch '%s'", os, arch,
-		)
+		// Let's catch M1 Macs that don't have a build yet and make them use rosetta2
+		if os == "darwin" && arch == "arm64" {
+			arch = "amd64"
+			for _, build := range r.Builds {
+				if build.OS == os && build.Arch == arch {
+					matchingBuild = build
+					break
+				}
+			}
+		} else {
+			return "", errors.Errorf(
+				"could not find matching build for OS '%s' and arch '%s'", os, arch,
+			)
+		}
+
 	}
 
 	return c.downloadBuild(matchingBuild)


### PR DESCRIPTION
After a check for a build that is native to to the host OS, currently it will fail for M1 macs. This does a second pass after confirm that it is an M1 mac and sets the arch to amd64 which will cause it to download a darwin amd64 build which is for Intel Macs which will run on M1 Macs via Rosetta 2.