### PR TITLE
feat: add custom arch support w/ env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ A seamless launcher for Terraform.
 
 Simply navigate to any folder that contains Terraform configuration and run `terraform` as you usually would. `terraform-demux` will attempt to locate the appropriate [version constraint](https://www.terraform.io/docs/language/expressions/version-constraints.html) by searching in the current working directory and recursively through parent directories. If `terraform-demux` cannot determine a constraint, it will default to the latest possible version.
 
+### Architecture Compatability
+
+`terraform-demux` supports a native `arm64` build that can also run `amd64` versions of `terraform` by specifying the `TF_DEMUX_ARCH` environment variable. This might be necessary for `terraform` workspaces that need older `terraform` versions that do not have `arm64` builds, or use older providers that do not have `arm64` builds.
+
+It is recommended to set up the following shell alias for handy `amd64` invocations:
+
+```sh
+alias terraform-amd64="TF_DEMUX_ARCH=amd64 terraform-demux"
+```
+
 ### Logging
 
 Setting the `TF_DEMUX_LOG` environment variable to any non-empty value will cause `terraform-demux` to write out debug logs to `stderr`.

--- a/cmd/terraform-demux/main.go
+++ b/cmd/terraform-demux/main.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"runtime"
 
 	"github.com/etsy/terraform-demux/internal/wrapper"
 )
@@ -17,9 +18,15 @@ func main() {
 		log.SetOutput(ioutil.Discard)
 	}
 
-	log.Printf("terraform-demux version %s", version)
+	arch := os.Getenv("TF_DEMUX_ARCH")
 
-	exitCode, err := wrapper.RunTerraform(os.Args[1:])
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
+
+	log.Printf("terraform-demux version %s, using arch '%s'", version, arch)
+
+	exitCode, err := wrapper.RunTerraform(os.Args[1:], arch)
 
 	if err != nil {
 		log.SetOutput(os.Stderr)

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func RunTerraform(args []string) (int, error) {
+func RunTerraform(args []string, arch string) (int, error) {
 	cacheDirectory, err := ensureCacheDirectory()
 
 	if err != nil {
@@ -53,7 +53,7 @@ func RunTerraform(args []string) (int, error) {
 
 	log.Printf("version '%s' matches all constraints", matchingRelease.Version)
 
-	executablePath, err := client.DownloadRelease(matchingRelease, runtime.GOOS, runtime.GOARCH)
+	executablePath, err := client.DownloadRelease(matchingRelease, runtime.GOOS, arch)
 
 	if err != nil {
 		return 1, err


### PR DESCRIPTION
We've recently added a darwin_arm64 build to terraform-demux, but that
can cause issues in Terraform workspaces that require older versions of
Terraform - depending on the version, some don't have darwin_arm64
builds, and even the ones that do may use Terraform providers that don't
have darwin_arm64 builds. In either case, the user is unable to run
terraform-demux as-is, and is forced to install the amd64 version.

This commit allows the user to override the architecture by specifying
an environment variable, and updates the README to match. It is expected
that users will set up the recommended shell alias and invoke the amd64
version of terraform when necessary, but otherwise use the native arm64
builds.

