### PR TITLE
fix: check err before using file object

### DIFF
--- a/internal/releaseapi/client.go
+++ b/internal/releaseapi/client.go
@@ -162,17 +162,20 @@ func (c *Client) downloadBuild(build Build, checkSha256Sum string) (string, erro
 	log.Printf("dowloading release archive from %s", build.URL)
 
 	zipFile, zipLength, err := c.downloadReleaseArchive(build)
-	defer os.Remove(zipFile.Name())
-	defer zipFile.Close()
 
 	if err != nil {
 		return "", err
 	}
 
+	defer os.Remove(zipFile.Name())
+	defer zipFile.Close()
+
 	f, err := os.Open(zipFile.Name())
+
 	if err != nil {
 		return "", errors.Wrap(err, "could not open zip archive")
 	}
+
 	defer f.Close()
 
 	h := sha256.New()


### PR DESCRIPTION
## Description

This change moves the order of operations around to check if there is an error returned by `downloadReleaseArchive` first before using the `zipFile` variable. In the case that there was a problem downloading the release archive from Hashicorp this function should return the originating error and not mask it with a nil pointer dereference.

## Context / Why are we making this change?

If there is an error downloading a release archive from Hashicorp, the `zipFile` variable will be `nil` and cause a panic on the deferred call to `os.Remove` due to a nil pointer dereference. This hides the underlying error and prevents the user from knowing what the actual problem is in downloading the release archive.
