### PR TITLE
chore: remove deprecated ioutil package

### DIFF
--- a/cmd/terraform-demux/main.go
+++ b/cmd/terraform-demux/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"runtime"
@@ -15,7 +15,7 @@ var (
 
 func main() {
 	if os.Getenv("TF_DEMUX_LOG") == "" {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	arch := os.Getenv("TF_DEMUX_ARCH")

--- a/internal/releaseapi/client.go
+++ b/internal/releaseapi/client.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -246,7 +245,7 @@ func (c *Client) downloadReleaseArchive(build Build) (*os.File, int64, error) {
 		return nil, 0, errors.Errorf("unexpected status code '%s' in response", response.StatusCode)
 	}
 
-	tmp, err := ioutil.TempFile("", filepath.Base(build.URL))
+	tmp, err := os.CreateTemp("", filepath.Base(build.URL))
 
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "could not create temporary file for release archive")


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

This PR removes the `ioutil` package and replaces calls to its functions with the equivalents from `os` and `io`.

## Context / Why are we making this change?

As of Go 1.16, that package has been deprecated (see https://pkg.go.dev/io/ioutil).

## Testing and QA Plan

I ran `test.sh` and built and ran a binary and tried `terraform login` and it worked.

## Impact

We will no longer be using the deprecated package.