### PR TITLE
chore: upgrade to Go 1.21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.21
 
       - name: Test
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.21
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/etsy/terraform-demux
 
-go 1.17
+go 1.21
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

This PR upgrades this project to use Go 1.21.

## Context / Why are we making this change?

Go 1.17 is no longer supported.

## Testing and QA Plan

I built the binary, manually tried logging in, and ran `test.sh`.

## Impact

This project will use the latest version of Go (1.21).