### PR TITLE
test: cover release/version logic and fix Windows exit code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,11 @@ jobs:
         with:
           go-version: 1.21
 
-      - name: Test
-        run: |
-          ./test.sh
+      - name: Unit tests
+        run: go test ./...
+
+      - name: Integration tests
+        run: ./test.sh
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/internal/releaseapi/client.go
+++ b/internal/releaseapi/client.go
@@ -20,7 +20,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
+// These are var rather than const so tests can override them to point at an
+// httptest server.
+var (
 	releasesURL    = "https://releases.hashicorp.com/terraform/index.json"
 	releaseRootURL = "https://releases.hashicorp.com/terraform"
 )

--- a/internal/releaseapi/client_test.go
+++ b/internal/releaseapi/client_test.go
@@ -1,0 +1,232 @@
+package releaseapi
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// fakeReleaseServer serves a single Terraform "release" so we can exercise
+// the full ListReleases + DownloadRelease pipeline without hitting
+// releases.hashicorp.com. It returns the server, the zip's sha256, and the
+// raw zip bytes (useful for tampering tests).
+func fakeReleaseServer(t *testing.T, version string) (*httptest.Server, string, []byte) {
+	t.Helper()
+
+	zipName := fmt.Sprintf("terraform_%s_%s_%s.zip", version, runtime.GOOS, runtime.GOARCH)
+	binName := "terraform"
+	if runtime.GOOS == "windows" {
+		binName = "terraform.exe"
+	}
+
+	// Build a minimal zip containing a "terraform" binary.
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, err := zw.Create(binName)
+	if err != nil {
+		t.Fatalf("zip create: %v", err)
+	}
+	if _, err := w.Write([]byte("#!/bin/sh\necho fake terraform " + version + "\n")); err != nil {
+		t.Fatalf("zip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	zipBytes := zipBuf.Bytes()
+
+	sum := sha256.Sum256(zipBytes)
+	hexSum := hex.EncodeToString(sum[:])
+	shasumsName := fmt.Sprintf("terraform_%s_SHA256SUMS", version)
+	shasumsBody := fmt.Sprintf("%s  %s\n", hexSum, zipName)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+
+	indexPath := "/index.json"
+	zipPath := fmt.Sprintf("/%s/%s", version, zipName)
+	shasumsPath := fmt.Sprintf("/%s/%s", version, shasumsName)
+
+	mux.HandleFunc(indexPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+  "versions": {
+    %q: {
+      "version": %q,
+      "shasums": %q,
+      "builds": [
+        {"version": %q, "os": %q, "arch": %q, "url": %q}
+      ]
+    }
+  }
+}`, version, version, shasumsName, version, runtime.GOOS, runtime.GOARCH, srv.URL+zipPath)
+	})
+	mux.HandleFunc(shasumsPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(shasumsBody))
+	})
+	mux.HandleFunc(zipPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(zipBytes)
+	})
+
+	t.Cleanup(srv.Close)
+	return srv, hexSum, zipBytes
+}
+
+func withTestURLs(t *testing.T, srvURL string) {
+	t.Helper()
+	origIndex, origRoot := releasesURL, releaseRootURL
+	releasesURL = srvURL + "/index.json"
+	releaseRootURL = srvURL
+	t.Cleanup(func() {
+		releasesURL = origIndex
+		releaseRootURL = origRoot
+	})
+}
+
+func TestListReleases_ParsesIndex(t *testing.T) {
+	srv, _, _ := fakeReleaseServer(t, "1.5.0")
+	withTestURLs(t, srv.URL)
+
+	c := NewClient(t.TempDir())
+	idx, err := c.ListReleases()
+	if err != nil {
+		t.Fatalf("ListReleases: %v", err)
+	}
+	r, ok := idx.Versions["1.5.0"]
+	if !ok {
+		t.Fatalf("expected version 1.5.0 in index, got %v", idx.Versions)
+	}
+	if r.Version.String() != "1.5.0" {
+		t.Errorf("got version %s, want 1.5.0", r.Version)
+	}
+	if len(r.Builds) != 1 {
+		t.Fatalf("expected 1 build, got %d", len(r.Builds))
+	}
+}
+
+func TestDownloadRelease_WritesAndCachesBinary(t *testing.T) {
+	srv, _, _ := fakeReleaseServer(t, "1.5.0")
+	withTestURLs(t, srv.URL)
+
+	cacheDir := t.TempDir()
+	c := NewClient(cacheDir)
+
+	idx, err := c.ListReleases()
+	if err != nil {
+		t.Fatalf("ListReleases: %v", err)
+	}
+	rel := idx.Versions["1.5.0"]
+
+	path, err := c.DownloadRelease(rel, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("DownloadRelease: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Errorf("downloaded binary is empty")
+	}
+	if filepath.Dir(path) != cacheDir {
+		t.Errorf("expected binary in cache dir %s, got %s", cacheDir, path)
+	}
+
+	// Second call should hit the cached binary (no re-download).
+	path2, err := c.DownloadRelease(rel, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("second DownloadRelease: %v", err)
+	}
+	if path != path2 {
+		t.Errorf("expected same cached path, got %s vs %s", path, path2)
+	}
+}
+
+func TestDownloadRelease_RejectsCorruptedArchive(t *testing.T) {
+	// Stand up a server where the zip body doesn't match the published
+	// SHA256SUMS — DownloadRelease must refuse it.
+	version := "1.5.0"
+	zipName := fmt.Sprintf("terraform_%s_%s_%s.zip", version, runtime.GOOS, runtime.GOARCH)
+	shasumsName := fmt.Sprintf("terraform_%s_SHA256SUMS", version)
+
+	// Pretend the zip has this checksum, but actually serve different bytes.
+	bogusSum := strings.Repeat("a", 64)
+	shasumsBody := fmt.Sprintf("%s  %s\n", bogusSum, zipName)
+
+	// Build a real-looking zip with arbitrary content.
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, _ := zw.Create("terraform")
+	_, _ = w.Write([]byte("not the right bytes"))
+	_ = zw.Close()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+  "versions": {
+    %q: {
+      "version": %q,
+      "shasums": %q,
+      "builds": [
+        {"version": %q, "os": %q, "arch": %q, "url": %q}
+      ]
+    }
+  }
+}`, version, version, shasumsName, version, runtime.GOOS, runtime.GOARCH,
+			srv.URL+"/"+version+"/"+zipName)
+	})
+	mux.HandleFunc("/"+version+"/"+shasumsName, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(shasumsBody))
+	})
+	mux.HandleFunc("/"+version+"/"+zipName, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(zipBuf.Bytes())
+	})
+
+	withTestURLs(t, srv.URL)
+
+	c := NewClient(t.TempDir())
+	idx, err := c.ListReleases()
+	if err != nil {
+		t.Fatalf("ListReleases: %v", err)
+	}
+	rel := idx.Versions[version]
+
+	_, err = c.DownloadRelease(rel, runtime.GOOS, runtime.GOARCH)
+	if err == nil {
+		t.Fatal("expected checksum mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "checksum") {
+		t.Errorf("expected checksum error, got: %v", err)
+	}
+}
+
+func TestDownloadRelease_NoBuildForOSArch(t *testing.T) {
+	srv, _, _ := fakeReleaseServer(t, "1.5.0")
+	withTestURLs(t, srv.URL)
+
+	c := NewClient(t.TempDir())
+	idx, err := c.ListReleases()
+	if err != nil {
+		t.Fatalf("ListReleases: %v", err)
+	}
+	rel := idx.Versions["1.5.0"]
+
+	_, err = c.DownloadRelease(rel, "plan9", "mips")
+	if err == nil {
+		t.Fatal("expected error for unknown os/arch, got nil")
+	}
+}

--- a/internal/wrapper/checkargs_test.go
+++ b/internal/wrapper/checkargs_test.go
@@ -1,18 +1,17 @@
 package wrapper
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
 )
 
 func TestCheckStateCommand(t *testing.T) {
-	STATE_COMMAND_VAR := "TF_DEMUX_ALLOW_STATE_COMMANDS"
+	const stateCommandVar = "TF_DEMUX_ALLOW_STATE_COMMANDS"
 	t.Run("Valid state import command with TF_DEMUX_ALLOW_STATE_COMMANDS on 1.5.0", func(t *testing.T) {
 		args := []string{"import", "--force"}
 		version, _ := semver.NewVersion("1.5.0")
-		os.Setenv(STATE_COMMAND_VAR, "true")
+		t.Setenv(stateCommandVar, "true")
 		err := checkStateCommand(args, version)
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -22,7 +21,7 @@ func TestCheckStateCommand(t *testing.T) {
 	t.Run("Valid state import command without TF_DEMUX_ALLOW_STATE_COMMANDS on 1.4.7", func(t *testing.T) {
 		args := []string{"import"}
 		version, _ := semver.NewVersion("1.4.7")
-		os.Setenv(STATE_COMMAND_VAR, "true")
+		t.Setenv(stateCommandVar, "true")
 		err := checkStateCommand(args, version)
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -32,7 +31,7 @@ func TestCheckStateCommand(t *testing.T) {
 	t.Run("Invalid state import command without TF_DEMUX_ALLOW_STATE_COMMANDS on 1.5.0", func(t *testing.T) {
 		args := []string{"import"}
 		version, _ := semver.NewVersion("1.6.0")
-		os.Setenv(STATE_COMMAND_VAR, "")
+		t.Setenv(stateCommandVar, "")
 		err := checkStateCommand(args, version)
 		if err == nil {
 			t.Errorf("Expected error, got: %v", err)
@@ -42,7 +41,7 @@ func TestCheckStateCommand(t *testing.T) {
 	t.Run("Valid state mv command with TF_DEMUX_ALLOW_STATE_COMMANDS on 1.6.0", func(t *testing.T) {
 		args := []string{"state", "mv", "--force"}
 		version, _ := semver.NewVersion("1.6.0")
-		os.Setenv(STATE_COMMAND_VAR, "true")
+		t.Setenv(stateCommandVar, "true")
 		err := checkStateCommand(args, version)
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -180,7 +180,7 @@ func runTerraform(executable string, args []string) (int, error) {
 
 	if err := cmd.Wait(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
-			return exitError.Sys().(syscall.WaitStatus).ExitStatus(), nil
+			return exitError.ExitCode(), nil
 		}
 
 		return 1, fmt.Errorf("error running Terraform: %v", err)

--- a/internal/wrapper/wrapper_test.go
+++ b/internal/wrapper/wrapper_test.go
@@ -1,0 +1,199 @@
+package wrapper
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/etsy/terraform-demux/internal/releaseapi"
+)
+
+func mustVersion(t *testing.T, s string) *semver.Version {
+	t.Helper()
+	v, err := semver.NewVersion(s)
+	if err != nil {
+		t.Fatalf("invalid version %q: %v", s, err)
+	}
+	return v
+}
+
+func mustConstraint(t *testing.T, s string) *semver.Constraints {
+	t.Helper()
+	c, err := semver.NewConstraint(s)
+	if err != nil {
+		t.Fatalf("invalid constraint %q: %v", s, err)
+	}
+	return c
+}
+
+func indexFromVersions(t *testing.T, versions ...string) releaseapi.ReleaseIndex {
+	t.Helper()
+	idx := releaseapi.ReleaseIndex{Versions: map[string]releaseapi.Release{}}
+	for _, v := range versions {
+		idx.Versions[v] = releaseapi.Release{Version: mustVersion(t, v)}
+	}
+	return idx
+}
+
+func TestFilterReleases_PicksNewestSatisfying(t *testing.T) {
+	idx := indexFromVersions(t, "0.11.15", "0.14.11", "1.0.3", "1.5.0", "1.7.2")
+
+	got, err := filterReleases(idx, []*semver.Constraints{mustConstraint(t, "~> 0.14.0")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version.String() != "0.14.11" {
+		t.Errorf("expected 0.14.11, got %s", got.Version)
+	}
+}
+
+func TestFilterReleases_MultipleConstraintsAreANDed(t *testing.T) {
+	idx := indexFromVersions(t, "1.0.3", "1.4.7", "1.5.0", "1.7.2")
+
+	got, err := filterReleases(idx, []*semver.Constraints{
+		mustConstraint(t, ">= 1.4.0"),
+		mustConstraint(t, "< 1.7.0"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version.String() != "1.5.0" {
+		t.Errorf("expected 1.5.0, got %s", got.Version)
+	}
+}
+
+func TestFilterReleases_NoMatchReturnsError(t *testing.T) {
+	idx := indexFromVersions(t, "1.0.3", "1.5.0")
+
+	_, err := filterReleases(idx, []*semver.Constraints{mustConstraint(t, ">= 2.0.0")})
+	if err == nil {
+		t.Fatal("expected error when no version satisfies constraints")
+	}
+}
+
+func TestFilterReleases_PrereleaseSkipped(t *testing.T) {
+	idx := releaseapi.ReleaseIndex{Versions: map[string]releaseapi.Release{
+		"1.6.6":     {Version: mustVersion(t, "1.6.6")},
+		"1.7.0-rc1": {Version: mustVersion(t, "1.7.0-rc1")},
+	}}
+
+	got, err := filterReleases(idx, []*semver.Constraints{mustConstraint(t, ">= 1.6.0")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version.String() != "1.6.6" {
+		t.Errorf("expected 1.6.6, got %s", got.Version)
+	}
+}
+
+func TestFilterReleases_NoConstraintsReturnsLatest(t *testing.T) {
+	idx := indexFromVersions(t, "1.0.3", "1.5.0", "1.7.2")
+
+	got, err := filterReleases(idx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version.String() != "1.7.2" {
+		t.Errorf("expected latest 1.7.2, got %s", got.Version)
+	}
+}
+
+func writeTerraformConfig(t *testing.T, dir, requiredVersion string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "terraform {\n  required_version = \"" + requiredVersion + "\"\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "terraform.tf"), []byte(body), 0644); err != nil {
+		t.Fatalf("write tf: %v", err)
+	}
+}
+
+func TestGetTerraformVersionConstraints_FoundInCwd(t *testing.T) {
+	dir := t.TempDir()
+	writeTerraformConfig(t, dir, "~> 1.5.0")
+
+	constraints, err := getTerraformVersionConstraints(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(constraints) != 1 {
+		t.Fatalf("expected 1 constraint, got %d", len(constraints))
+	}
+	if !constraints[0].Check(mustVersion(t, "1.5.7")) {
+		t.Errorf("constraint should accept 1.5.7")
+	}
+	if constraints[0].Check(mustVersion(t, "1.6.0")) {
+		t.Errorf("constraint should reject 1.6.0")
+	}
+}
+
+func TestGetTerraformVersionConstraints_WalksUpToParent(t *testing.T) {
+	root := t.TempDir()
+	writeTerraformConfig(t, root, ">= 1.0.0")
+	child := filepath.Join(root, "modules", "foo")
+	if err := os.MkdirAll(child, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	constraints, err := getTerraformVersionConstraints(child)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(constraints) != 1 {
+		t.Fatalf("expected to find parent's constraint, got %d", len(constraints))
+	}
+}
+
+func TestGetTerraformVersionConstraints_NoneFound(t *testing.T) {
+	// Empty tempdir up to filesystem root yields no constraints (assumes no
+	// stray /terraform.tf at the root, which is safe in practice).
+	dir := t.TempDir()
+
+	constraints, err := getTerraformVersionConstraints(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if constraints != nil {
+		t.Errorf("expected nil constraints, got %v", constraints)
+	}
+}
+
+// TestRunTerraform_ExitCodePropagation regression-tests C3: the wrapper must
+// return the same exit code as the wrapped binary on every supported
+// platform. The previous syscall.WaitStatus type assertion was not portable
+// to Windows. We invoke the test binary itself as a fake "terraform" via the
+// TestHelperProcess pattern.
+func TestRunTerraform_ExitCodePropagation(t *testing.T) {
+	for _, want := range []int{0, 1, 2, 42} {
+		want := want
+		t.Run(strconv.Itoa(want), func(t *testing.T) {
+			t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+			t.Setenv("HELPER_EXIT_CODE", strconv.Itoa(want))
+
+			got, err := runTerraform(os.Args[0], []string{
+				"-test.run=TestHelperProcess", "--", "fake-terraform",
+			})
+			if err != nil {
+				t.Fatalf("runTerraform: %v", err)
+			}
+			if got != want {
+				t.Errorf("got exit code %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestHelperProcess is not a real test — it's the child process spawned by
+// TestRunTerraform_ExitCodePropagation. When invoked with
+// GO_WANT_HELPER_PROCESS=1 it exits with HELPER_EXIT_CODE.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	code, _ := strconv.Atoi(os.Getenv("HELPER_EXIT_CODE"))
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- Fix portability bug in `runTerraform`: `exitError.Sys().(syscall.WaitStatus).ExitStatus()` is Unix-only and was broken on Windows. Switched to `exitError.ExitCode()`.
- Backfill unit tests around the previously-untested core: `filterReleases`, `getTerraformVersionConstraints`, `releaseapi.Client` (via `httptest`), and an end-to-end exit-code propagation regression test that would have caught the Windows bug.
- CI now runs `go test ./...` in addition to the existing integration script. Previously the unit tests in `internal/wrapper` were never executed by CI.
- Migrated `checkargs_test.go` from `os.Setenv` to `t.Setenv` so subtests don't leak env state.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass (wrapper, releaseapi)
- [x] Manually exercised the launcher against all three `testdata/` fixtures (`-version` returns the expected Terraform version)

## Notes
- `releaseapi/client.go` switches `releasesURL` / `releaseRootURL` from `const` to `var` so tests can point the client at an `httptest` server. Behavior is unchanged.
- This PR intentionally does not address the other findings from the recent review (silent-checksum skip, naive state-command arg matching, signal-channel buffering, etc.); those will be follow-up PRs.