### PR TITLE
fix: address critical and high-severity issues from code review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.21
 
@@ -23,8 +23,9 @@ jobs:
         run: ./test.sh
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
+          version: '~> v2'
           args: build --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,32 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.21
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit homebrew forumulaa
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          export MESSAGE="chore: regenerate homebrew formula"
-          export SHA=$(git rev-parse --verify origin/main:Formula/terraform-demux.rb)
-          export CONTENT=$(base64 -i dist/homebrew/Formula/terraform-demux.rb)
-          gh api --method PUT /repos/:owner/:repo/contents/Formula/terraform-demux.rb \
-            --field message="$MESSAGE" \
-            --field content="$CONTENT" \
-            --field encoding="base64" \
-            --field sha="$SHA"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - main: ./cmd/terraform-demux
     env:
@@ -14,16 +16,15 @@ builds:
         goarch: arm64
 
 brews:
-  - tap:
+  - repository:
       owner: etsy
-      name:  terraform-demux
+      name: terraform-demux
 
-    folder:      Formula
-    skip_upload: true
+    directory: Formula
 
-    homepage:    https://github.com/etsy/terraform-demux
+    homepage: https://github.com/etsy/terraform-demux
     description: A user-friendly launcher (à la Bazelisk) for Terraform.
-    license:     "Apache-2.0"
+    license: "Apache-2.0"
 
     conflicts:
       - "terraform"

--- a/cmd/terraform-demux/main.go
+++ b/cmd/terraform-demux/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io"
+	"bytes"
 	"log"
 	"os"
 	"runtime"
@@ -14,12 +14,18 @@ var (
 )
 
 func main() {
-	if os.Getenv("TF_DEMUX_LOG") == "" {
-		log.SetOutput(io.Discard)
+	// When TF_DEMUX_LOG is unset, hold log output in a buffer so we can
+	// replay it on stderr if something goes wrong. Otherwise the user only
+	// sees the final error message and not the trace that led to it.
+	var logBuf bytes.Buffer
+	verboseLogging := os.Getenv("TF_DEMUX_LOG") != ""
+	if verboseLogging {
+		log.SetOutput(os.Stderr)
+	} else {
+		log.SetOutput(&logBuf)
 	}
 
 	arch := os.Getenv("TF_DEMUX_ARCH")
-
 	if arch == "" {
 		arch = runtime.GOARCH
 	}
@@ -27,10 +33,11 @@ func main() {
 	log.Printf("terraform-demux version %s, using arch '%s'", version, arch)
 
 	exitCode, err := wrapper.RunTerraform(os.Args[1:], arch)
-
 	if err != nil {
+		if !verboseLogging {
+			os.Stderr.Write(logBuf.Bytes())
+		}
 		log.SetOutput(os.Stderr)
-
 		log.Fatal("error: ", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20231204233900-a34142ec2a72
 	github.com/natefinch/atomic v1.0.1
-	github.com/pkg/errors v0.9.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0
 github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/internal/releaseapi/client.go
+++ b/internal/releaseapi/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -17,7 +18,6 @@ import (
 	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/diskcache"
 	"github.com/natefinch/atomic"
-	"github.com/pkg/errors"
 )
 
 // These are var rather than const so tests can override them to point at an
@@ -25,6 +25,11 @@ import (
 var (
 	releasesURL    = "https://releases.hashicorp.com/terraform/index.json"
 	releaseRootURL = "https://releases.hashicorp.com/terraform"
+)
+
+const (
+	httpCacheSubdir = "http"
+	binCacheSubdir  = "bin"
 )
 
 type ReleaseIndex struct {
@@ -45,16 +50,26 @@ type Build struct {
 }
 
 type Client struct {
-	cacheDir   string
+	binDir     string
 	httpClient *http.Client
 }
 
-func NewClient(cacheDir string) *Client {
-	httpClient := httpcache.NewTransport(
-		diskcache.New(cacheDir),
-	).Client()
+// NewClient prepares a Client that writes httpcache entries and downloaded
+// binaries into separate subdirectories of cacheDir, so the two never
+// commingle.
+func NewClient(cacheDir string) (*Client, error) {
+	httpDir := filepath.Join(cacheDir, httpCacheSubdir)
+	binDir := filepath.Join(cacheDir, binCacheSubdir)
 
-	return &Client{cacheDir, httpClient}
+	if err := os.MkdirAll(httpDir, 0755); err != nil {
+		return nil, fmt.Errorf("could not create http cache dir %q: %w", httpDir, err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return nil, fmt.Errorf("could not create bin cache dir %q: %w", binDir, err)
+	}
+
+	httpClient := httpcache.NewTransport(diskcache.New(httpDir)).Client()
+	return &Client{binDir: binDir, httpClient: httpClient}, nil
 }
 
 func (c *Client) ListReleases() (ReleaseIndex, error) {
@@ -63,29 +78,26 @@ func (c *Client) ListReleases() (ReleaseIndex, error) {
 	log.Printf("downloading Terraform release index")
 
 	request, err := http.NewRequest("GET", releasesURL, nil)
-
 	if err != nil {
-		return releaseIndex, errors.Wrap(err, "could not create request for Terraform release index")
+		return releaseIndex, fmt.Errorf("could not create request for Terraform release index: %w", err)
 	}
 
 	response, err := c.httpClient.Do(request)
-
 	if err != nil {
-		return releaseIndex, errors.Wrap(err, "could not send request for Terraform release index")
-	} else if response.StatusCode != http.StatusOK {
-		return releaseIndex, errors.Errorf("error: unexpected status code '%d' in response", response.StatusCode)
+		return releaseIndex, fmt.Errorf("could not send request for Terraform release index: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return releaseIndex, fmt.Errorf("unexpected status code %d when fetching Terraform release index", response.StatusCode)
 	}
 
 	if response.Header.Get(httpcache.XFromCache) != "" {
 		log.Printf("using cached response")
 	}
 
-	defer response.Body.Close()
-
-	decoder := json.NewDecoder(response.Body)
-
-	if err := decoder.Decode(&releaseIndex); err != nil {
-		return releaseIndex, errors.Wrap(err, "could not unmarshal release index JSON")
+	if err := json.NewDecoder(response.Body).Decode(&releaseIndex); err != nil {
+		return releaseIndex, fmt.Errorf("could not unmarshal release index JSON: %w", err)
 	}
 
 	return releaseIndex, nil
@@ -93,112 +105,128 @@ func (c *Client) ListReleases() (ReleaseIndex, error) {
 
 func (c *Client) DownloadRelease(r Release, os, arch string) (string, error) {
 	var matchingBuild Build
-	var checkSha256Sum string
 	for _, build := range r.Builds {
 		if build.OS == os && build.Arch == arch {
 			matchingBuild = build
 			break
 		}
 	}
-
 	if matchingBuild.URL == "" {
-		return "", errors.Errorf(
-			"could not find matching build for OS '%s' and arch '%s'", os, arch,
-		)
+		return "", fmt.Errorf("could not find matching build for OS %q and arch %q", os, arch)
+	}
+	// Mirrors the nil-version skipping done in filterReleases: the cache
+	// path uses Build.Version.String(), so a missing version field would
+	// otherwise panic later in executableName().
+	if matchingBuild.Version == nil {
+		matchingBuild.Version = r.Version
+	}
+	if matchingBuild.Version == nil {
+		return "", fmt.Errorf("release for OS %q arch %q has no version", os, arch)
 	}
 
-	checkSums, err := c.getReleaseCheckSums(r)
+	expectedSum, err := c.expectedChecksumFor(r, &matchingBuild)
 	if err != nil {
-		return "", errors.Wrap(err, "could not download checksum file")
+		return "", err
 	}
 
-	for _, line := range strings.Split(checkSums, "\n") {
-		checksum := strings.Split(line, "  ")
-		if checksum[1] == matchingBuild.zipFileName() {
-			checkSha256Sum = checksum[0]
-			break
+	return c.downloadBuild(matchingBuild, expectedSum)
+}
+
+// expectedChecksumFor downloads the SHA256SUMS file for the release and looks
+// up the entry matching this build's archive filename. It is a hard failure
+// if the SHA256SUMS file cannot be downloaded or contains no entry for the
+// archive — checksum verification must never silently no-op.
+func (c *Client) expectedChecksumFor(r Release, build *Build) (string, error) {
+	body, err := c.getReleaseCheckSums(r)
+	if err != nil {
+		return "", fmt.Errorf("could not download checksum file: %w", err)
+	}
+
+	target := build.zipFileName()
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Each line is "<hex-sha256>  <filename>" — Fields tolerates the
+		// canonical two-space separator and any unexpected whitespace
+		// without panicking on malformed entries.
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[1] == target {
+			return parts[0], nil
 		}
 	}
 
-	build, err := c.downloadBuild(matchingBuild, checkSha256Sum)
-	return build, err
+	return "", fmt.Errorf("no checksum entry for %q in SHA256SUMS for Terraform %s", target, r.Version)
 }
 
 func (c *Client) getReleaseCheckSums(release Release) (string, error) {
 	request, err := http.NewRequest("GET", release.ShaSumsURL(), nil)
 	if err != nil {
-		return "", errors.Wrap(err, "could not create request for Terraform release checksum")
+		return "", fmt.Errorf("could not create request for Terraform release checksum: %w", err)
 	}
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return "", errors.Wrap(err, "could not send request for Terraform release checksum")
+		return "", fmt.Errorf("could not send request for Terraform release checksum: %w", err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		return "", errors.Errorf("error: unexpected status code '%d' in response", response.StatusCode)
+		return "", fmt.Errorf("unexpected status code %d when fetching SHA256SUMS", response.StatusCode)
 	}
 
-	bodyBytes, err := io.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "error: could not read response")
+		return "", fmt.Errorf("could not read SHA256SUMS body: %w", err)
 	}
-	checkSums := string(bodyBytes)
-	return checkSums, nil
+	return string(body), nil
 }
 
 func (r *Release) ShaSumsURL() string {
 	return fmt.Sprintf("%s/%s/%s", releaseRootURL, r.Version, r.Shasums)
 }
 
-func (c *Client) downloadBuild(build Build, checkSha256Sum string) (string, error) {
-	path := cachedExecutablePath(c.cacheDir, build)
+func (c *Client) downloadBuild(build Build, expectedSum string) (string, error) {
+	path := cachedExecutablePath(c.binDir, build)
 
 	if _, err := os.Stat(path); err == nil {
 		log.Printf("found cached Terraform executable at %s", path)
 		return path, nil
 	} else if !os.IsNotExist(err) {
-		return "", errors.Wrap(err, "could not stat Terraform executable")
+		return "", fmt.Errorf("could not stat Terraform executable: %w", err)
 	}
 
-	log.Printf("dowloading release archive from %s", build.URL)
+	log.Printf("downloading release archive from %s", build.URL)
 
 	zipFile, zipLength, err := c.downloadReleaseArchive(build)
-
 	if err != nil {
 		return "", err
 	}
-
 	defer os.Remove(zipFile.Name())
 	defer zipFile.Close()
 
 	f, err := os.Open(zipFile.Name())
-
 	if err != nil {
-		return "", errors.Wrap(err, "could not open zip archive")
+		return "", fmt.Errorf("could not open zip archive: %w", err)
 	}
-
 	defer f.Close()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
-		return "", errors.Wrap(err, "could not check sha256sum for zip archive")
+		return "", fmt.Errorf("could not compute sha256 for zip archive: %w", err)
 	}
-	sha256Sum := h.Sum(nil)
+	actualSum := hex.EncodeToString(h.Sum(nil))
 
-	if checkSha256Sum != "" {
-		if checkSha256Sum != hex.EncodeToString(sha256Sum) {
-			return "", errors.Errorf(
-				"checksum for %s should be %s, got %s", build.URL, checkSha256Sum, hex.EncodeToString(sha256Sum),
-			)
-		} else {
-			log.Printf("checksum match\n")
-		}
+	if expectedSum != actualSum {
+		return "", fmt.Errorf("checksum for %s should be %s, got %s", build.URL, expectedSum, actualSum)
 	}
+	log.Printf("checksum match")
 
 	zipReader, err := zip.NewReader(zipFile, zipLength)
-
 	if err != nil {
-		return "", errors.Wrap(err, "could not unzip release archive")
+		return "", fmt.Errorf("could not unzip release archive: %w", err)
 	}
 
 	binaryName := build.archiveBinaryName()
@@ -208,21 +236,17 @@ func (c *Client) downloadBuild(build Build, checkSha256Sum string) (string, erro
 		}
 
 		source, err := f.Open()
-
 		if err != nil {
-			return "", errors.Wrap(err, "could not read binary in release archive")
+			return "", fmt.Errorf("could not read binary in release archive: %w", err)
 		}
-
 		defer source.Close()
 
 		if err := atomic.WriteFile(path, source); err != nil {
-			return "", errors.Wrap(err, "could not write binary to the cache directory")
+			return "", fmt.Errorf("could not write binary to the cache directory: %w", err)
 		}
-
 		if err := os.Chmod(path, 0700); err != nil {
-			return "", errors.Wrap(err, "could not make binary executable")
+			return "", fmt.Errorf("could not make binary executable: %w", err)
 		}
-
 		return path, nil
 	}
 
@@ -231,47 +255,40 @@ func (c *Client) downloadBuild(build Build, checkSha256Sum string) (string, erro
 
 func (c *Client) downloadReleaseArchive(build Build) (*os.File, int64, error) {
 	request, err := http.NewRequest("GET", build.URL, nil)
-
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "could not create request for release archive")
+		return nil, 0, fmt.Errorf("could not create request for release archive: %w", err)
 	}
-
 	request.Header.Set("Cache-Control", "no-store")
 
 	response, err := c.httpClient.Do(request)
-
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "could not download release archive")
+		return nil, 0, fmt.Errorf("could not download release archive: %w", err)
 	}
-
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, 0, errors.Errorf("unexpected status code '%d' in response", response.StatusCode)
+		return nil, 0, fmt.Errorf("unexpected status code %d when downloading release archive", response.StatusCode)
 	}
 
 	tmp, err := os.CreateTemp("", filepath.Base(build.URL))
-
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "could not create temporary file for release archive")
+		return nil, 0, fmt.Errorf("could not create temporary file for release archive: %w", err)
 	}
-
 	if _, err := io.Copy(tmp, response.Body); err != nil {
-		return nil, 0, errors.Wrap(err, "could not copy release archive to temporary file")
+		return nil, 0, fmt.Errorf("could not copy release archive to temporary file: %w", err)
 	}
 	return tmp, response.ContentLength, nil
 }
 
-func cachedExecutablePath(cacheDir string, b Build) string {
-	return filepath.Join(cacheDir, b.executableName())
+func cachedExecutablePath(binDir string, b Build) string {
+	return filepath.Join(binDir, b.executableName())
 }
 
 func (b *Build) archiveBinaryName() string {
-	extension := ""
 	if b.OS == "windows" {
-		extension = ".exe"
+		return "terraform.exe"
 	}
-	return "terraform" + extension
+	return "terraform"
 }
 
 func (b *Build) executableName() string {

--- a/internal/releaseapi/client_test.go
+++ b/internal/releaseapi/client_test.go
@@ -97,7 +97,10 @@ func TestListReleases_ParsesIndex(t *testing.T) {
 	srv, _, _ := fakeReleaseServer(t, "1.5.0")
 	withTestURLs(t, srv.URL)
 
-	c := NewClient(t.TempDir())
+	c, err := NewClient(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
 	idx, err := c.ListReleases()
 	if err != nil {
 		t.Fatalf("ListReleases: %v", err)
@@ -119,7 +122,10 @@ func TestDownloadRelease_WritesAndCachesBinary(t *testing.T) {
 	withTestURLs(t, srv.URL)
 
 	cacheDir := t.TempDir()
-	c := NewClient(cacheDir)
+	c, err := NewClient(cacheDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
 
 	idx, err := c.ListReleases()
 	if err != nil {
@@ -139,8 +145,9 @@ func TestDownloadRelease_WritesAndCachesBinary(t *testing.T) {
 	if info.Size() == 0 {
 		t.Errorf("downloaded binary is empty")
 	}
-	if filepath.Dir(path) != cacheDir {
-		t.Errorf("expected binary in cache dir %s, got %s", cacheDir, path)
+	wantDir := filepath.Join(cacheDir, "bin")
+	if filepath.Dir(path) != wantDir {
+		t.Errorf("expected binary in %s, got %s", wantDir, path)
 	}
 
 	// Second call should hit the cached binary (no re-download).
@@ -198,7 +205,10 @@ func TestDownloadRelease_RejectsCorruptedArchive(t *testing.T) {
 
 	withTestURLs(t, srv.URL)
 
-	c := NewClient(t.TempDir())
+	c, err := NewClient(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
 	idx, err := c.ListReleases()
 	if err != nil {
 		t.Fatalf("ListReleases: %v", err)
@@ -218,7 +228,10 @@ func TestDownloadRelease_NoBuildForOSArch(t *testing.T) {
 	srv, _, _ := fakeReleaseServer(t, "1.5.0")
 	withTestURLs(t, srv.URL)
 
-	c := NewClient(t.TempDir())
+	c, err := NewClient(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
 	idx, err := c.ListReleases()
 	if err != nil {
 		t.Fatalf("ListReleases: %v", err)
@@ -228,5 +241,175 @@ func TestDownloadRelease_NoBuildForOSArch(t *testing.T) {
 	_, err = c.DownloadRelease(rel, "plan9", "mips")
 	if err == nil {
 		t.Fatal("expected error for unknown os/arch, got nil")
+	}
+}
+
+// TestDownloadRelease_FailsWhenSumNotInChecksumFile is a regression test for
+// C1: previously a missing entry in SHA256SUMS caused checkSha256Sum to stay
+// "" and the verification was silently skipped. Now the entire flow must
+// fail.
+func TestDownloadRelease_FailsWhenSumNotInChecksumFile(t *testing.T) {
+	version := "1.5.0"
+	zipName := fmt.Sprintf("terraform_%s_%s_%s.zip", version, runtime.GOOS, runtime.GOARCH)
+	shasumsName := fmt.Sprintf("terraform_%s_SHA256SUMS", version)
+
+	// SHA256SUMS deliberately lists a different filename, so no entry
+	// matches our build's zip.
+	shasumsBody := fmt.Sprintf("%s  some_other_file.zip\n", strings.Repeat("a", 64))
+
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, _ := zw.Create("terraform")
+	_, _ = w.Write([]byte("payload"))
+	_ = zw.Close()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"versions":{%q:{"version":%q,"shasums":%q,"builds":[{"version":%q,"os":%q,"arch":%q,"url":%q}]}}}`,
+			version, version, shasumsName, version, runtime.GOOS, runtime.GOARCH,
+			srv.URL+"/"+version+"/"+zipName)
+	})
+	mux.HandleFunc("/"+version+"/"+shasumsName, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(shasumsBody))
+	})
+	mux.HandleFunc("/"+version+"/"+zipName, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(zipBuf.Bytes())
+	})
+
+	withTestURLs(t, srv.URL)
+
+	c, err := NewClient(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	idx, err := c.ListReleases()
+	if err != nil {
+		t.Fatalf("ListReleases: %v", err)
+	}
+	rel := idx.Versions[version]
+
+	_, err = c.DownloadRelease(rel, runtime.GOOS, runtime.GOARCH)
+	if err == nil {
+		t.Fatal("expected error when SHA256SUMS has no matching entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "no checksum entry") {
+		t.Errorf("expected no-checksum-entry error, got: %v", err)
+	}
+}
+
+// TestDownloadRelease_TolerantSHASUMSParse is a regression test: a
+// SHA256SUMS file with extra blank lines and oddly-spaced entries must not
+// panic the parser (the previous strings.Split(line, "  ") + checksum[1]
+// path would index past the end of the slice).
+func TestDownloadRelease_TolerantSHASUMSParse(t *testing.T) {
+	version := "1.5.0"
+	zipName := fmt.Sprintf("terraform_%s_%s_%s.zip", version, runtime.GOOS, runtime.GOARCH)
+	shasumsName := fmt.Sprintf("terraform_%s_SHA256SUMS", version)
+
+	binName := "terraform"
+	if runtime.GOOS == "windows" {
+		binName = "terraform.exe"
+	}
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, _ := zw.Create(binName)
+	_, _ = w.Write([]byte("payload"))
+	_ = zw.Close()
+	zipBytes := zipBuf.Bytes()
+	sum := sha256.Sum256(zipBytes)
+	hexSum := hex.EncodeToString(sum[:])
+
+	// Mix in: blank lines, a malformed single-token line, extra whitespace,
+	// a legitimate line for our zip.
+	shasumsBody := strings.Join([]string{
+		"",
+		"   ",
+		"malformedline",
+		fmt.Sprintf("%s  some_other.zip", strings.Repeat("b", 64)),
+		fmt.Sprintf("%s  %s", hexSum, zipName),
+		"",
+	}, "\n")
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"versions":{%q:{"version":%q,"shasums":%q,"builds":[{"version":%q,"os":%q,"arch":%q,"url":%q}]}}}`,
+			version, version, shasumsName, version, runtime.GOOS, runtime.GOARCH,
+			srv.URL+"/"+version+"/"+zipName)
+	})
+	mux.HandleFunc("/"+version+"/"+shasumsName, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(shasumsBody))
+	})
+	mux.HandleFunc("/"+version+"/"+zipName, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(zipBytes)
+	})
+
+	withTestURLs(t, srv.URL)
+
+	c, err := NewClient(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	idx, err := c.ListReleases()
+	if err != nil {
+		t.Fatalf("ListReleases: %v", err)
+	}
+	rel := idx.Versions[version]
+
+	_, err = c.DownloadRelease(rel, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("expected success despite messy SHA256SUMS, got: %v", err)
+	}
+}
+
+// TestDownloadRelease_FallsBackToReleaseVersion: when the upstream JSON has
+// no "version" field on a Build (or it fails to decode), DownloadRelease
+// must not panic in executableName(). It falls back to Release.Version.
+func TestDownloadRelease_FallsBackToReleaseVersion(t *testing.T) {
+	srv, _, _ := fakeReleaseServer(t, "1.5.0")
+	withTestURLs(t, srv.URL)
+
+	c, err := NewClient(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	idx, err := c.ListReleases()
+	if err != nil {
+		t.Fatalf("ListReleases: %v", err)
+	}
+	rel := idx.Versions["1.5.0"]
+	for i := range rel.Builds {
+		rel.Builds[i].Version = nil
+	}
+
+	path, err := c.DownloadRelease(rel, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("expected fallback to release Version, got: %v", err)
+	}
+	if !strings.Contains(path, "1.5.0") {
+		t.Errorf("expected path to include version, got: %s", path)
+	}
+}
+
+func TestNewClient_CreatesSubdirs(t *testing.T) {
+	cacheDir := t.TempDir()
+	if _, err := NewClient(cacheDir); err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	for _, sub := range []string{"http", "bin"} {
+		path := filepath.Join(cacheDir, sub)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("expected %s subdir, got: %v", sub, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%s exists but is not a directory", path)
+		}
 	}
 }

--- a/internal/wrapper/checkargs.go
+++ b/internal/wrapper/checkargs.go
@@ -8,56 +8,61 @@ import (
 	"github.com/Masterminds/semver/v3"
 )
 
+const stateCommandVar = "TF_DEMUX_ALLOW_STATE_COMMANDS"
+
 func checkStateCommand(args []string, version *semver.Version) error {
-	versionImport, _ := semver.NewConstraint(">= 1.5.0")
-	versionMoved, _ := semver.NewConstraint(">= 1.1.0")
-	versionRemoved, _ := semver.NewConstraint(">= 1.7.0")
-	STATE_COMMAND_VAR := "TF_DEMUX_ALLOW_STATE_COMMANDS"
-
-	errorMsg := func(command string, suggestion string) error {
-		return fmt.Errorf("refusing to execute '%s' command - use a '%s' configuration block instead, or set %s=true", command, suggestion, STATE_COMMAND_VAR)
-	}
-
-	if allowStateCommand(STATE_COMMAND_VAR) {
+	if allowStateCommand(stateCommandVar) {
 		return nil
 	}
 
-	if checkArgsExists(args, "import") >= 0 &&
-		versionImport.Check(version) {
-		return errorMsg("import", "import")
-	}
+	versionImport, _ := semver.NewConstraint(">= 1.5.0")
+	versionMoved, _ := semver.NewConstraint(">= 1.1.0")
+	versionRemoved, _ := semver.NewConstraint(">= 1.7.0")
 
-	if checkArgsExists(args, "state") >= 0 &&
-		checkArgsExists(args, "mv") >= 0 &&
-		versionMoved.Check(version) {
-		return errorMsg("state mv", "moved")
-	}
+	cmd, sub := terraformSubcommand(args)
 
-	if checkArgsExists(args, "state") >= 0 &&
-		checkArgsExists(args, "rm") >= 0 &&
-		versionRemoved.Check(version) {
-		return errorMsg("state rm", "removed")
+	switch {
+	case cmd == "import" && versionImport.Check(version):
+		return refuseStateCommand("import", "import")
+	case cmd == "state" && sub == "mv" && versionMoved.Check(version):
+		return refuseStateCommand("state mv", "moved")
+	case cmd == "state" && sub == "rm" && versionRemoved.Check(version):
+		return refuseStateCommand("state rm", "removed")
 	}
-
 	return nil
 }
 
-func checkArgsExists(args []string, cmd string) int {
-	for i, arg := range args {
-		if arg == cmd {
-			return i
+// terraformSubcommand returns the first and second positional arguments,
+// ignoring anything that looks like a flag. This avoids false positives where
+// a flag value contains a literal like "import" or "mv" (e.g. -var=action=mv).
+// It does not handle the rare "-flag value" form, but Terraform's CLI almost
+// universally uses "-flag=value".
+func terraformSubcommand(args []string) (cmd, sub string) {
+	var positional []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			continue
 		}
+		positional = append(positional, a)
 	}
-	return -1
+	if len(positional) > 0 {
+		cmd = positional[0]
+	}
+	if len(positional) > 1 {
+		sub = positional[1]
+	}
+	return
+}
+
+func refuseStateCommand(cmd, suggestion string) error {
+	return fmt.Errorf("refusing to execute '%s' command - use a '%s' configuration block instead, or set %s=true", cmd, suggestion, stateCommandVar)
 }
 
 func allowStateCommand(envVarName string) bool {
-	validValues := []string{"1", "true", "yes"}
 	value := strings.ToLower(os.Getenv(envVarName))
-	for _, valid := range validValues {
-		if value == valid {
-			return true
-		}
+	switch value {
+	case "1", "true", "yes":
+		return true
 	}
 	return false
 }

--- a/internal/wrapper/checkargs_test.go
+++ b/internal/wrapper/checkargs_test.go
@@ -7,74 +7,113 @@ import (
 )
 
 func TestCheckStateCommand(t *testing.T) {
-	const stateCommandVar = "TF_DEMUX_ALLOW_STATE_COMMANDS"
-	t.Run("Valid state import command with TF_DEMUX_ALLOW_STATE_COMMANDS on 1.5.0", func(t *testing.T) {
-		args := []string{"import", "--force"}
-		version, _ := semver.NewVersion("1.5.0")
+	t.Run("import allowed when env var set", func(t *testing.T) {
 		t.Setenv(stateCommandVar, "true")
-		err := checkStateCommand(args, version)
+		err := checkStateCommand([]string{"import", "module.foo", "id"}, mustVer(t, "1.5.0"))
 		if err != nil {
-			t.Errorf("Expected no error, got: %v", err)
+			t.Errorf("expected no error, got: %v", err)
 		}
 	})
 
-	t.Run("Valid state import command without TF_DEMUX_ALLOW_STATE_COMMANDS on 1.4.7", func(t *testing.T) {
-		args := []string{"import"}
-		version, _ := semver.NewVersion("1.4.7")
-		t.Setenv(stateCommandVar, "true")
-		err := checkStateCommand(args, version)
-		if err != nil {
-			t.Errorf("Expected no error, got: %v", err)
-		}
-	})
-
-	t.Run("Invalid state import command without TF_DEMUX_ALLOW_STATE_COMMANDS on 1.5.0", func(t *testing.T) {
-		args := []string{"import"}
-		version, _ := semver.NewVersion("1.6.0")
+	t.Run("import allowed on pre-1.5.0 even without env var", func(t *testing.T) {
 		t.Setenv(stateCommandVar, "")
-		err := checkStateCommand(args, version)
-		if err == nil {
-			t.Errorf("Expected error, got: %v", err)
+		err := checkStateCommand([]string{"import"}, mustVer(t, "1.4.7"))
+		if err != nil {
+			t.Errorf("expected no error, got: %v", err)
 		}
 	})
 
-	t.Run("Valid state mv command with TF_DEMUX_ALLOW_STATE_COMMANDS on 1.6.0", func(t *testing.T) {
-		args := []string{"state", "mv", "--force"}
-		version, _ := semver.NewVersion("1.6.0")
+	t.Run("import refused on 1.6.0 without env var", func(t *testing.T) {
+		t.Setenv(stateCommandVar, "")
+		err := checkStateCommand([]string{"import", "module.foo", "id"}, mustVer(t, "1.6.0"))
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("state mv allowed when env var set", func(t *testing.T) {
 		t.Setenv(stateCommandVar, "true")
-		err := checkStateCommand(args, version)
+		err := checkStateCommand([]string{"state", "mv", "--force"}, mustVer(t, "1.6.0"))
 		if err != nil {
-			t.Errorf("Expected no error, got: %v", err)
+			t.Errorf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("state mv refused on 1.1.0+ without env var", func(t *testing.T) {
+		t.Setenv(stateCommandVar, "")
+		err := checkStateCommand([]string{"state", "mv", "a", "b"}, mustVer(t, "1.6.0"))
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("state rm refused on 1.7.0+ without env var", func(t *testing.T) {
+		t.Setenv(stateCommandVar, "")
+		err := checkStateCommand([]string{"state", "rm", "module.foo"}, mustVer(t, "1.7.0"))
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	// H4 regression: a flag value that happens to contain "import", "mv",
+	// or "rm" must not trigger the guard. The guard is supposed to match
+	// only the actual subcommand.
+	t.Run("flag value containing 'import' does not trip guard", func(t *testing.T) {
+		t.Setenv(stateCommandVar, "")
+		err := checkStateCommand([]string{"apply", "-var=action=import"}, mustVer(t, "1.6.0"))
+		if err != nil {
+			t.Errorf("expected no error for apply with -var=action=import, got: %v", err)
+		}
+	})
+
+	t.Run("flag value containing 'mv' does not trip guard", func(t *testing.T) {
+		t.Setenv(stateCommandVar, "")
+		err := checkStateCommand(
+			[]string{"plan", "-target=module.state.mv"},
+			mustVer(t, "1.6.0"),
+		)
+		if err != nil {
+			t.Errorf("expected no error for plan with -target=module.state.mv, got: %v", err)
+		}
+	})
+
+	t.Run("'mv' before 'state' positionally does not trip guard", func(t *testing.T) {
+		t.Setenv(stateCommandVar, "")
+		// 'mv' is the subcommand here (made up), not 'state mv'.
+		err := checkStateCommand([]string{"mv", "state"}, mustVer(t, "1.6.0"))
+		if err != nil {
+			t.Errorf("expected no error, got: %v", err)
 		}
 	})
 }
 
-func TestCheckArgsExists(t *testing.T) {
-	t.Run("Check 'import --force' command", func(t *testing.T) {
-		args := []string{"import", "--force"}
-		result := checkArgsExists(args, "import")
-		if result != 0 {
-			t.Errorf("Expected 0, got: %v", result)
+func TestTerraformSubcommand(t *testing.T) {
+	cases := []struct {
+		args    []string
+		wantCmd string
+		wantSub string
+	}{
+		{[]string{"import", "module.foo", "id"}, "import", "module.foo"},
+		{[]string{"-chdir=/tmp", "state", "mv", "a", "b"}, "state", "mv"},
+		{[]string{"apply", "-var=action=import"}, "apply", ""},
+		{[]string{"plan", "-target=module.state.mv"}, "plan", ""},
+		{[]string{}, "", ""},
+		{[]string{"-help"}, "", ""},
+	}
+	for _, tc := range cases {
+		gotCmd, gotSub := terraformSubcommand(tc.args)
+		if gotCmd != tc.wantCmd || gotSub != tc.wantSub {
+			t.Errorf("terraformSubcommand(%v) = (%q, %q), want (%q, %q)",
+				tc.args, gotCmd, gotSub, tc.wantCmd, tc.wantSub)
 		}
-		result = checkArgsExists(args, "--force")
-		if result != 1 {
-			t.Errorf("Expected 1, got: %v", result)
-		}
-	})
+	}
+}
 
-	t.Run("Check 'state moved' command", func(t *testing.T) {
-		args := []string{"state", "mv"}
-		result := checkArgsExists(args, "state")
-		if result != 0 {
-			t.Errorf("Expected 0, got: %v", result)
-		}
-		result = checkArgsExists(args, "mv")
-		if result != 1 {
-			t.Errorf("Expected 1, got: %v", result)
-		}
-		result = checkArgsExists(args, "--force")
-		if result != -1 {
-			t.Errorf("Expected -1, got: %v", result)
-		}
-	})
+func mustVer(t *testing.T, s string) *semver.Version {
+	t.Helper()
+	v, err := semver.NewVersion(s)
+	if err != nil {
+		t.Fatalf("invalid version %q: %v", s, err)
+	}
+	return v
 }

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -15,38 +15,35 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
-	"github.com/pkg/errors"
 )
 
 func RunTerraform(args []string, arch string) (int, error) {
 	cacheDirectory, err := ensureCacheDirectory()
-
 	if err != nil {
 		return 1, err
 	}
 
 	workingDirectory, err := os.Getwd()
-
 	if err != nil {
-		return 1, errors.Wrap(err, "could not get working directory")
+		return 1, fmt.Errorf("could not get working directory: %w", err)
 	}
 
 	terraformVersionConstraints, err := getTerraformVersionConstraints(workingDirectory)
-
 	if err != nil {
 		return 1, err
 	}
 
-	client := releaseapi.NewClient(cacheDirectory)
+	client, err := releaseapi.NewClient(cacheDirectory)
+	if err != nil {
+		return 1, err
+	}
 
 	releaseIndex, err := client.ListReleases()
-
 	if err != nil {
 		return 1, err
 	}
 
 	matchingRelease, err := filterReleases(releaseIndex, terraformVersionConstraints)
-
 	if err != nil {
 		return 1, err
 	}
@@ -58,7 +55,6 @@ func RunTerraform(args []string, arch string) (int, error) {
 	}
 
 	executablePath, err := client.DownloadRelease(matchingRelease, runtime.GOOS, arch)
-
 	if err != nil {
 		return 1, err
 	}
@@ -68,15 +64,13 @@ func RunTerraform(args []string, arch string) (int, error) {
 
 func ensureCacheDirectory() (string, error) {
 	userCacheDir, err := os.UserCacheDir()
-
 	if err != nil {
-		return "", errors.Wrap(err, "could not determine user's cache directory")
+		return "", fmt.Errorf("could not determine user's cache directory: %w", err)
 	}
 
 	wrapperCacheDir := filepath.Join(userCacheDir, "terraform-demux")
-
 	if err := os.MkdirAll(wrapperCacheDir, 0755); err != nil {
-		return "", errors.Wrapf(err, "could not create cache directory '%s'", wrapperCacheDir)
+		return "", fmt.Errorf("could not create cache directory %q: %w", wrapperCacheDir, err)
 	}
 
 	return wrapperCacheDir, nil
@@ -90,23 +84,26 @@ func getTerraformVersionConstraints(directory string) ([]*semver.Constraints, er
 
 		module, diags := tfconfig.LoadModule(currentDirectory)
 
+		// LoadModule returns success with an empty module when the directory
+		// has no .tf files, so HasErrors() means a real parse problem in
+		// something the user wrote — surface it instead of silently
+		// falling through to the latest stable release.
 		if diags.HasErrors() {
-			log.Printf("encountered error parsing configuration: %v", diags.Err())
-		} else if len(module.RequiredCore) > 0 {
+			return nil, fmt.Errorf("invalid terraform configuration in %s: %w", currentDirectory, diags.Err())
+		}
+
+		if len(module.RequiredCore) > 0 {
 			var allConstraints []*semver.Constraints
 
 			for _, constraintString := range module.RequiredCore {
 				constraints, err := semver.NewConstraint(constraintString)
-
 				if err != nil {
-					return nil, errors.Wrap(err, "could not determine constraint from string")
+					return nil, fmt.Errorf("could not parse required_version %q: %w", constraintString, err)
 				}
-
 				allConstraints = append(allConstraints, constraints)
 			}
 
 			log.Printf("found constraints: %v", allConstraints)
-
 			return allConstraints, nil
 		}
 
@@ -114,7 +111,6 @@ func getTerraformVersionConstraints(directory string) ([]*semver.Constraints, er
 
 		if parentDirectory == currentDirectory {
 			log.Printf("no constraints found")
-
 			return nil, nil
 		}
 
@@ -126,6 +122,11 @@ func filterReleases(index releaseapi.ReleaseIndex, constraints []*semver.Constra
 	var versions semver.Collection
 
 	for _, release := range index.Versions {
+		// Defensive: a release may decode without a Version (missing or
+		// unparseable field). Skip rather than panic on later access.
+		if release.Version == nil {
+			continue
+		}
 		if release.Version.Prerelease() != "" {
 			continue
 		}
@@ -143,38 +144,41 @@ ReleaseVersionLoop:
 			}
 		}
 
-		// this version matched all of the constraints, so we return early
 		return index.Versions[version.String()], nil
 	}
 
-	// no version matches all constraints
-	return releaseapi.Release{}, errors.Errorf(
-		"no Terraform releases appear to satisfy all of the following constraints: %v", constraints,
-	)
+	return releaseapi.Release{}, fmt.Errorf("no Terraform releases appear to satisfy all of the following constraints: %v", constraints)
 }
 
-// runTerraform executes Terraform and returns the exit code as an integer.
+// runTerraform executes Terraform and returns its exit code.
 // Based on https://github.com/bazelbuild/bazelisk/blob/97a0d60468dc696cea3cf1d252b526f1ac6a9090/core/core.go#L405.
 func runTerraform(executable string, args []string) (int, error) {
 	cmd := makeTerraformCmd(executable, args)
 
-	err := cmd.Start()
-
-	if err != nil {
-		return 1, errors.Errorf("could not start Terraform: %v", err)
+	if err := cmd.Start(); err != nil {
+		return 1, fmt.Errorf("could not start Terraform: %w", err)
 	}
 
-	c := make(chan os.Signal)
-
+	// Buffered so signal.Notify never drops a delivery.
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(c)
+
+	done := make(chan struct{})
+	defer close(done)
 
 	go func() {
-		s := <-c
-
-		if runtime.GOOS != "windows" {
-			cmd.Process.Signal(s)
-		} else {
-			cmd.Process.Kill()
+		for {
+			select {
+			case s := <-c:
+				if runtime.GOOS == "windows" {
+					_ = cmd.Process.Kill()
+				} else {
+					_ = cmd.Process.Signal(s)
+				}
+			case <-done:
+				return
+			}
 		}
 	}()
 
@@ -182,8 +186,7 @@ func runTerraform(executable string, args []string) (int, error) {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			return exitError.ExitCode(), nil
 		}
-
-		return 1, fmt.Errorf("error running Terraform: %v", err)
+		return 1, fmt.Errorf("error running Terraform: %w", err)
 	}
 
 	return 0, nil

--- a/internal/wrapper/wrapper_test.go
+++ b/internal/wrapper/wrapper_test.go
@@ -162,6 +162,39 @@ func TestGetTerraformVersionConstraints_NoneFound(t *testing.T) {
 	}
 }
 
+// H3 regression: a syntactically-broken terraform.tf must not be silently
+// swallowed and treated as "no constraint" (which would then resolve to the
+// latest stable Terraform). The error has to surface.
+func TestGetTerraformVersionConstraints_SurfacesParseError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "terraform.tf"), []byte("this is not valid hcl {{{"), 0644); err != nil {
+		t.Fatalf("write tf: %v", err)
+	}
+
+	_, err := getTerraformVersionConstraints(dir)
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+// H2 regression: a release with a nil Version (e.g., the upstream JSON
+// omits or fails to decode the "version" field) must be skipped, not
+// dereferenced.
+func TestFilterReleases_SkipsNilVersion(t *testing.T) {
+	idx := releaseapi.ReleaseIndex{Versions: map[string]releaseapi.Release{
+		"1.5.0": {Version: mustVersion(t, "1.5.0")},
+		"bogus": {Version: nil},
+	}}
+
+	got, err := filterReleases(idx, []*semver.Constraints{mustConstraint(t, ">= 1.0.0")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version.String() != "1.5.0" {
+		t.Errorf("expected 1.5.0, got %s", got.Version)
+	}
+}
+
 // TestRunTerraform_ExitCodePropagation regression-tests C3: the wrapper must
 // return the same exit code as the wrapped binary on every supported
 // platform. The previous syscall.WaitStatus type assertion was not portable


### PR DESCRIPTION
**Stacks on top of #18 — please merge that first; this branch will rebase cleanly against main once it lands.**

Bundles the remaining items from the recent review (C3, H5, H7 already in #18).

## Critical
- **C1** Hard-fail when `SHA256SUMS` contains no entry for the requested archive instead of silently skipping verification. Also bounds-check parsing so a malformed line can no longer panic the splitter. (`internal/releaseapi/client.go`)
- **C2** Split the cache directory into `<cacheDir>/http` and `<cacheDir>/bin` so httpcache blobs and downloaded binaries don't commingle. (`internal/releaseapi/client.go`)
- **C4** Buffered `os.Signal` channel, deferred `signal.Stop`, and a done-channel for the forwarding goroutine so a second Ctrl-C is no longer dropped. Also clears the previous `go vet` warning. (`internal/wrapper/wrapper.go`)
- **C5** When `TF_DEMUX_LOG` is unset, hold log output in a `bytes.Buffer` and replay it on stderr only when an error occurs. Verbose mode still streams directly to stderr. (`cmd/terraform-demux/main.go`)

## High
- **H2** `filterReleases` skips entries whose `Version` is nil instead of dereferencing them. (`internal/wrapper/wrapper.go`)
- **H3** Surface tfconfig parse errors instead of swallowing them and silently falling through to the latest stable release. (`internal/wrapper/wrapper.go`)
- **H4** Rewrite the state-command guard to match `import` / `state mv` / `state rm` only as positional Terraform subcommands, so flag values like `-var=action=import` or `-target=module.state.mv` no longer falsely refuse legitimate operations. (`internal/wrapper/checkargs.go`)
- **H6** Migrate off the archived `github.com/pkg/errors` in favor of `fmt.Errorf(\"...: %w\", err)` and stdlib `errors`. Note: `golang.org/x/text v0.3.8` already contains the fix for CVE-2022-32149 — no version bump needed.
- **H8** Drop the manual `gh api PUT` step in `release.yaml` (stale-SHA race, plus typo) and let goreleaser publish the Homebrew formula natively. Renames `tap:`->`repository:` and `folder:`->`directory:` to match goreleaser v2 schema.

## Tests added
- SHA256SUMS missing-entry hard-fail
- Tolerance for malformed/blank lines in SHA256SUMS
- `NewClient` creates `http/` and `bin/` subdirs
- Parse error surfacing from `getTerraformVersionConstraints`
- Nil-version skipping in `filterReleases`
- State guard false-positive cases (`-var=...=import`, `-target=...mv...`, etc.)
- Table-driven `TestTerraformSubcommand` for the new positional parser

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean (was previously failing on the unbuffered signal channel)
- [x] Smoke test: success path is silent (C5); error path (`TF_DEMUX_ARCH=fakearch td-bin -version`) replays the buffered trace to stderr before the final error message
- [x] Existing testdata fixtures still resolve correctly under `TF_DEMUX_ARCH=amd64`

## Note on H8 risk
Switching to goreleaser-native homebrew publishing means the next tag-triggered release will use git push (default goreleaser behavior) instead of the GitHub Contents API to update `Formula/terraform-demux.rb`. The default `GITHUB_TOKEN` already has `contents: write` (granted at workflow level), so this should work — but branch-protection / CODEOWNERS behavior on `main` is unchanged and worth confirming separately.