### PR TITLE
chore: publish v2.1.0 homebrew formula and switch to PR-based publishing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,13 @@ brews:
   - repository:
       owner: etsy
       name: terraform-demux
+      # main branch protection requires verified signatures and PR review,
+      # so goreleaser cannot push the formula directly. Opening a PR lets
+      # GitHub sign the merge commit and satisfies branch protection.
+      pull_request:
+        enabled: true
+
+    commit_msg_template: "chore: regenerate homebrew formula"
 
     directory: Formula
 

--- a/Formula/terraform-demux.rb
+++ b/Formula/terraform-demux.rb
@@ -5,13 +5,13 @@
 class TerraformDemux < Formula
   desc "A user-friendly launcher (à la Bazelisk) for Terraform."
   homepage "https://github.com/etsy/terraform-demux"
-  version "2.0.0"
+  version "2.1.0"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/etsy/terraform-demux/releases/download/v2.0.0/terraform-demux_2.0.0_darwin_amd64.tar.gz"
-      sha256 "00bef96b0ecafdcb09c15e99a1a1218c78dc3aff6acccbaaa135bb3902d2ddc7"
+      url "https://github.com/etsy/terraform-demux/releases/download/v2.1.0/terraform-demux_2.1.0_darwin_amd64.tar.gz"
+      sha256 "867b9252ea1b31b3aa12bbba1fba6953f552c49f5c410601f9857f4e9a28eb8f"
 
       def install
         bin.install "terraform-demux"
@@ -19,8 +19,8 @@ class TerraformDemux < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/etsy/terraform-demux/releases/download/v2.0.0/terraform-demux_2.0.0_darwin_arm64.tar.gz"
-      sha256 "e7eff1f217f1807a6e94167a9fbe7c02ea471c9c91e24c547fe128d7f28e1221"
+      url "https://github.com/etsy/terraform-demux/releases/download/v2.1.0/terraform-demux_2.1.0_darwin_arm64.tar.gz"
+      sha256 "ba8306fd2c4031be48492d87da2aaec051634d050eb07b1753cf37ab55d98ed2"
 
       def install
         bin.install "terraform-demux"
@@ -31,8 +31,8 @@ class TerraformDemux < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/etsy/terraform-demux/releases/download/v2.0.0/terraform-demux_2.0.0_linux_arm64.tar.gz"
-      sha256 "dcc370cc6b7c651236645796fe4bee1bc22ccacb4ddda754037c5fd251e71649"
+      url "https://github.com/etsy/terraform-demux/releases/download/v2.1.0/terraform-demux_2.1.0_linux_arm64.tar.gz"
+      sha256 "6110a08b8feeedf90948f574c9b88ef8048aa411ee420f24dfa77d1e98f1430f"
 
       def install
         bin.install "terraform-demux"
@@ -40,8 +40,8 @@ class TerraformDemux < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/etsy/terraform-demux/releases/download/v2.0.0/terraform-demux_2.0.0_linux_amd64.tar.gz"
-      sha256 "0516bd7ad17cab3ef85763da64cca23dc919f0d8e5d49c84210b17c29542f5f8"
+      url "https://github.com/etsy/terraform-demux/releases/download/v2.1.0/terraform-demux_2.1.0_linux_amd64.tar.gz"
+      sha256 "dd2a3d8642deb07731adee2baaa57a3780b3c251c7d1bc3f713fb0330427a0e1"
 
       def install
         bin.install "terraform-demux"


### PR DESCRIPTION
## Context
The v2.1.0 release was published successfully — binaries are at https://github.com/etsy/terraform-demux/releases/tag/v2.1.0 — but the final step that pushes the updated Homebrew formula to \`main\` failed:

> homebrew formula: could not update \"Formula/terraform-demux.rb\": ... 409 Could not update file: Commits must have verified signatures. Changes must be made through a pull request.

\`main\` branch protection now requires verified signatures and PR review, and goreleaser's default direct Contents API PUT cannot satisfy either.

## Changes
1. **\`Formula/terraform-demux.rb\`** — bumped to v2.1.0 with the published SHA256s from \`terraform-demux_2.1.0_checksums.txt\`:
   - darwin/amd64 \`867b9252...\`
   - darwin/arm64 \`ba8306fd...\`
   - linux/amd64  \`dd2a3d86...\`
   - linux/arm64  \`6110a08b...\`
2. **\`.goreleaser.yaml\`** — set \`brews[].repository.pull_request.enabled: true\` and added \`commit_msg_template: \"chore: regenerate homebrew formula\"\`. Future releases will land the formula update via a PR whose merge commit GitHub auto-signs, instead of attempting a direct push that branch protection rejects.

## Test plan
- [x] Verified the new SHA256s match the published checksums.txt artifact byte-for-byte.
- [x] Formula structure unchanged (same on_macos / on_linux blocks, same install logic).
- [ ] Next release (v2.1.1+) will exercise the new \`pull_request\` flow end-to-end.