### PR TITLE
ci: publish homebrew formula via SSH deploy key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,3 +29,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,15 @@ brews:
   - repository:
       owner: etsy
       name: terraform-demux
+      branch: main
+      # Push the formula update over SSH using a deploy key, so the
+      # commit is attributed to a Rulesets bypass actor (Deploy keys)
+      # and is not blocked by branch protection on main.
+      git:
+        url: 'git@github.com:etsy/terraform-demux.git'
+        private_key: '{{ .Env.RELEASE_DEPLOY_KEY }}'
+
+    commit_msg_template: "chore: regenerate homebrew formula"
 
     directory: Formula
 


### PR DESCRIPTION
## Why

After v2.1.0/v2.1.1/v2.1.2, when branch protection on \`main\` requires verified signatures and PR review, goreleaser's default Contents API push is blocked because:
- The actor making the API call is the built-in \`github-actions[bot]\`, which Rulesets do not list as a selectable bypass actor.
- API commits via the default \`GITHUB_TOKEN\` are not GPG-verified.

Deploy keys, by contrast, *are* a selectable Rulesets bypass actor type and authenticate over SSH/git.

## What this changes

- \`.goreleaser.yaml\`: under \`brews[].repository\`, configure \`git.url\` (SSH) + \`git.private_key\` from \`\${{ .Env.RELEASE_DEPLOY_KEY }}\`. Pin \`branch: main\`. Also adds \`commit_msg_template: \"chore: regenerate homebrew formula\"\` to preserve the existing commit-message style.
- \`.github/workflows/release.yaml\`: pass \`RELEASE_DEPLOY_KEY\` from repo secrets to the goreleaser step's environment.

## Setup checklist (must be done before this lands or the next release will fail)

- [x] Add the public key as a **Deploy key** under Settings → Deploy keys, with "Allow write access" checked.
- [x] Add the matching private key as a repo secret named \`RELEASE_DEPLOY_KEY\`.
- [x] In the Ruleset's bypass list, add **Deploy keys** as a bypass actor.

## Test plan

- [ ] Once merged, cut a small patch tag (e.g. v2.1.3) to validate the end-to-end flow with the new deploy-key path before re-enabling protection rules.